### PR TITLE
Extremely draft implementation of user registration/login

### DIFF
--- a/Sources/alloclient/AlloUserClient.swift
+++ b/Sources/alloclient/AlloUserClient.swift
@@ -18,10 +18,10 @@ public class AlloUserClient : AlloClient
         didSet { userTransport.microphoneEnabled = micEnabled }
     }
     
-    public override init(url: URL, avatarDescription: EntityDescription)
+    public override init(url: URL, authentication: AuthenticationContext, avatarDescription: EntityDescription)
     {
         self.micEnabled = true
-        super.init(url: url, avatarDescription: avatarDescription)
+        super.init(url: url, authentication: authentication, avatarDescription: avatarDescription)
     }
     
     open override func reset()

--- a/Sources/alloclient/AlloUserClient.swift
+++ b/Sources/alloclient/AlloUserClient.swift
@@ -18,10 +18,10 @@ public class AlloUserClient : AlloClient
         didSet { userTransport.microphoneEnabled = micEnabled }
     }
     
-    public override init(url: URL, authentication: AuthenticationContext, avatarDescription: EntityDescription)
+    public override init(url: URL, identity: Identity, avatarDescription: EntityDescription)
     {
         self.micEnabled = true
-        super.init(url: url, authentication: authentication, avatarDescription: avatarDescription)
+        super.init(url: url, identity: identity, avatarDescription: avatarDescription)
     }
     
     open override func reset()

--- a/Sources/allonet2/AlloClient.swift
+++ b/Sources/allonet2/AlloClient.swift
@@ -20,6 +20,7 @@ open class AlloClient : AlloSessionDelegate, ObservableObject, Identifiable
     public let placeState = PlaceState()
     
     let url: URL
+    let authentication: AuthenticationContext
     let avatarDesc: EntityDescription
     @Published public private(set) var avatarId: EntityID? { didSet { isAnnounced = avatarId != nil } }
     public var avatar: Entity? {
@@ -57,10 +58,11 @@ open class AlloClient : AlloSessionDelegate, ObservableObject, Identifiable
         }
     }
     
-    public init(url: URL, avatarDescription: EntityDescription)
+    public init(url: URL, authentication: AuthenticationContext, avatarDescription: EntityDescription)
     {
         Allonet.Initialize()
         self.url = url
+        self.authentication = authentication
         self.avatarDesc = avatarDescription
         self.reset()
     }
@@ -214,7 +216,7 @@ open class AlloClient : AlloSessionDelegate, ObservableObject, Identifiable
                 type: .request,
                 senderEntityId: "",
                 receiverEntityId: Interaction.PlaceEntity,
-                body: .announce(version: "2.0", avatar: avatarDesc)
+                body: .announce(version: "2.0", authentication: authentication, avatar: avatarDesc)
             ))
             guard case .announceResponse(let avatarId, let placeName) = response.body else
             {

--- a/Sources/allonet2/AlloClient.swift
+++ b/Sources/allonet2/AlloClient.swift
@@ -20,7 +20,7 @@ open class AlloClient : AlloSessionDelegate, ObservableObject, Identifiable
     public let placeState = PlaceState()
     
     let url: URL
-    let authentication: AuthenticationContext
+    let identity: Identity
     let avatarDesc: EntityDescription
     @Published public private(set) var avatarId: EntityID? { didSet { isAnnounced = avatarId != nil } }
     public var avatar: Entity? {
@@ -58,11 +58,11 @@ open class AlloClient : AlloSessionDelegate, ObservableObject, Identifiable
         }
     }
     
-    public init(url: URL, authentication: AuthenticationContext, avatarDescription: EntityDescription)
+    public init(url: URL, identity: Identity, avatarDescription: EntityDescription)
     {
         Allonet.Initialize()
         self.url = url
-        self.authentication = authentication
+        self.identity = identity
         self.avatarDesc = avatarDescription
         self.reset()
     }
@@ -216,7 +216,7 @@ open class AlloClient : AlloSessionDelegate, ObservableObject, Identifiable
                 type: .request,
                 senderEntityId: "",
                 receiverEntityId: Interaction.PlaceEntity,
-                body: .announce(version: "2.0", authentication: authentication, avatar: avatarDesc)
+                body: .announce(version: "2.0", identity: identity, avatar: avatarDesc)
             ))
             guard case .announceResponse(let avatarId, let placeName) = response.body else
             {

--- a/Sources/allonet2/AlloClient.swift
+++ b/Sources/allonet2/AlloClient.swift
@@ -349,7 +349,7 @@ open class AlloClient : AlloSessionDelegate, ObservableObject, Identifiable
     
     // MARK: - Convenience API
     
-    func request(receiverEntityId: EntityID, body: InteractionBody) async -> Interaction
+    public func request(receiverEntityId: EntityID, body: InteractionBody) async -> Interaction
     {
         precondition(avatarId != nil, "Must be connected and announced to send a request")
         return await session.request(interaction: Interaction(type: .request, senderEntityId: avatarId!, receiverEntityId: receiverEntityId, body: body))

--- a/Sources/allonet2/Interaction.swift
+++ b/Sources/allonet2/Interaction.swift
@@ -48,7 +48,7 @@ public enum InteractionType: Codable
 public enum InteractionBody : Codable
 {
     // - Agent to Place
-    case announce(version: String, authentication: AuthenticationContext, avatar: EntityDescription) // -> .announceResponse
+    case announce(version: String, identity: Identity, avatar: EntityDescription) // -> .announceResponse
     case announceResponse(avatarId: String, placeName: String)
     
     case createEntity(EntityDescription) // -> .createEntityResponse
@@ -58,7 +58,7 @@ public enum InteractionBody : Codable
 
     // - Authentication (App agent to place)
     case registerAsAuthenticationProvider // -> .success or .error
-    case authenticationRequest(authentication: AuthenticationContext) // -> .success or .error
+    case authenticationRequest(identity: Identity) // -> .success or .error
 
     // - Agent to agent
     case tap(at: SIMD3<Float>) // oneway
@@ -84,10 +84,27 @@ public enum InteractionBody : Codable
     }
 }
 
-public enum AuthenticationContext: Equatable, Hashable, Codable, Sendable {
-    case none
-    case existingUser(username: String, password: String)
-    case registerUser(username: String, password: String)
+public struct Identity: Equatable, Hashable, Codable, Sendable
+{
+    public enum Expectation: Equatable, Hashable, Codable, Sendable
+    {
+        case none // The originating party has no expectations about the status of the identity.
+        case existingUser // The originating party expects that this is a previously-registered user.
+        case newUser // The originating party expects that this is a registration for a brand new user.
+    }
+
+    public init(expectation: Identity.Expectation, displayName: String, emailAddress: String, authenticationToken: String)
+    {
+        self.expectation = expectation
+        self.displayName = displayName
+        self.emailAddress = emailAddress
+        self.authenticationToken = authenticationToken
+    }
+    
+    public let expectation: Expectation
+    public let displayName: String
+    public let emailAddress: String
+    public let authenticationToken: String // Could be a password, a passkey token, etc.
 }
 
 public enum EntityRemovalMode: String, Codable

--- a/Sources/allonet2/Interaction.swift
+++ b/Sources/allonet2/Interaction.swift
@@ -48,14 +48,18 @@ public enum InteractionType: Codable
 public enum InteractionBody : Codable
 {
     // - Agent to Place
-    case announce(version: String, avatar: EntityDescription) // -> .announceResponse
+    case announce(version: String, authentication: AuthenticationContext, avatar: EntityDescription) // -> .announceResponse
     case announceResponse(avatarId: String, placeName: String)
     
     case createEntity(EntityDescription) // -> .createEntityResponse
     case createEntityResponse(entityId: EntityID)
     case removeEntity(entityId: EntityID, mode: EntityRemovalMode) // -> .success or .error
     case changeEntity(entityId: EntityID, addOrChange: [AnyComponent], remove: [ComponentTypeID]) // -> .success or .error
-    
+
+    // - Authentication (App agent to place)
+    case registerAsAuthenticationProvider // -> .success or .error
+    case authenticationRequest(authentication: AuthenticationContext) // -> .success or .error
+
     // - Agent to agent
     case tap(at: SIMD3<Float>) // oneway
     
@@ -78,6 +82,12 @@ public enum InteractionBody : Codable
         }
         return description
     }
+}
+
+public enum AuthenticationContext: Equatable, Hashable, Codable, Sendable {
+    case none
+    case existingUser(username: String, password: String)
+    case registerUser(username: String, password: String)
 }
 
 public enum EntityRemovalMode: String, Codable

--- a/Sources/allonet2/Interaction.swift
+++ b/Sources/allonet2/Interaction.swift
@@ -86,6 +86,8 @@ public enum InteractionBody : Codable
 
 public struct Identity: Equatable, Hashable, Codable, Sendable
 {
+    public static let none = Identity(expectation: .none, displayName: "", emailAddress: "", authenticationToken: "")
+
     public enum Expectation: Equatable, Hashable, Codable, Sendable
     {
         case none // The originating party has no expectations about the status of the identity.

--- a/Sources/allonet2/PlaceServer.swift
+++ b/Sources/allonet2/PlaceServer.swift
@@ -180,7 +180,10 @@ public class PlaceServer : AlloSessionDelegate
     
     nonisolated public func session(didDisconnect sess: AlloSession)
     {
-        let cid = sess.clientId!
+        guard let cid = sess.clientId else {
+            print("Lost client before a client ID was set - this may be due to an auth failure")
+            return
+        }
         print("Lost client \(cid)")
         Task { @MainActor in
             if let _ = self.clients.removeValue(forKey: cid)


### PR DESCRIPTION
This PR is a very early stab at implementing user authentication by deferring such authentication to a connected agent.

This is done by:

- Added  a `.registerAsAuthenticationProvider` interaction to allow an agent to register itself as an auth provider with the place server.
- Added an `.authenticationRequest(AuthenticationContext)` interaction to allow the place server to defer authentication to a registered agent.
- Added an `AuthenticationContext` parameter to the `.announce` interaction.

The flow is as follows: 

```
[User Client]                       [Place]                                     [Agent]
     |                                 |                                           |
     |                                 |      <-- announce(auth: .none) --         |
     |                                 |  <-- registerAsAuthenticationProvider --  |
     |                                 |                                           |
     |  -- announce(auth: .login) -->  |                                           |
     |                                 |      -- authenticationRequest -->         |
     |                                 |            <-- (response) --              |
     |        <-- (response) --        |                                           |
     |                                 |                                           |
```