### PR TITLE
Improve announce handling

### DIFF
--- a/Sources/allonet2/AlloClient.swift
+++ b/Sources/allonet2/AlloClient.swift
@@ -232,13 +232,15 @@ open class AlloClient : AlloSessionDelegate, ObservableObject, Identifiable, Ent
             guard case .announceResponse(let avatarId, let placeName) = response.body else
             {
                 print("Announce failed: \(response)")
-                // TODO: Fill in lastError and make it a permanent disconnect
+                self.connectionStatus.lastError = AlloverseError(with: response.body)
+                self.connectionStatus.reconnection = .idle
                 self.disconnect()
                 return
             }
             print("Received announce response: \(response.body)")
             self.avatarId = avatarId
             self.placeName = placeName
+            self.connectionStatus.hasReceivedAnnounceResponse = true
             await heartbeat.markChanged()
         }
     }

--- a/Sources/allonet2/AlloClient.swift
+++ b/Sources/allonet2/AlloClient.swift
@@ -12,8 +12,14 @@ import FoundationNetworking
 import OpenCombineShim
 
 @MainActor
-open class AlloClient : AlloSessionDelegate, ObservableObject, Identifiable, EntityMutator
+open class AlloClient : AlloSessionDelegate, ObservableObject, Identifiable, EntityMutator, Equatable
 {
+    public static func == (lhs: AlloClient, rhs: AlloClient) -> Bool
+    {
+        // .id is `nil` until the connection is established, so we can't really use that.
+        return lhs.url == rhs.url && lhs.identity == rhs.identity
+    }
+
     /// Convenient access to the contents of the connected Place.
     public private(set) lazy var place = Place(state: placeState, client: self)
     /// Access to the more complicated underlying data model for the connected Place.

--- a/Sources/allonet2/ConnectionStatus.swift
+++ b/Sources/allonet2/ConnectionStatus.swift
@@ -42,11 +42,14 @@ public class ConnectionStatus: ObservableObject
     @Published public var iceGathering: ConnectionState = .idle
     @Published public var iceConnection: ConnectionState = .idle
     @Published public var data: ConnectionState = .idle
-    
+
+    // Set to true once the connection/session has received a successful announce response.
+    @Published public var hasReceivedAnnounceResponse: Bool = false
+
     var debugDescription: String {
         "state: \(reconnection), error: \(String(describing: self.lastError)), willReconnectAt: \(String(describing: self.willReconnectAt))"
     }
-    public init(reconnection: ReconnectionState = .idle, lastError: Error? = nil, willReconnectAt: Date? = nil, signalling: ConnectionState = .idle, iceGathering: ConnectionState = .idle, iceConnection: ConnectionState = .idle, data: ConnectionState = .idle)
+    public init(reconnection: ReconnectionState = .idle, lastError: Error? = nil, willReconnectAt: Date? = nil, signalling: ConnectionState = .idle, iceGathering: ConnectionState = .idle, iceConnection: ConnectionState = .idle, data: ConnectionState = .idle, hasReceivedAnnounceResponse: Bool = false)
     {
         self.reconnection = reconnection
         self.lastError = lastError
@@ -55,5 +58,6 @@ public class ConnectionStatus: ObservableObject
         self.iceGathering = iceGathering
         self.iceConnection = iceConnection
         self.data = data
+        self.hasReceivedAnnounceResponse = hasReceivedAnnounceResponse
     }
 }


### PR DESCRIPTION
This PR has some minor improvements to how announces are handled - if an announce gets a failure response, the connection status will be updated with an error and a state update. 

It also adds a `hasReceivedAnnounceResponse` property` to `ConnectionStatus` that clients can observe.