### PR TITLE
Support custom components

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,13 +36,12 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/christophhagen/BinaryCodable", from: "3.0.0"),
-        //.package(url: "https://github.com/apple/swift-protobuf.git", .upToNextMajor(from: "1.25.1")),
+          .package(url: "https://github.com/outfoxx/PotentCodables.git", from: "3.5.3"),
+
         .package(url: "https://github.com/livekit/webrtc-xcframework.git", exact: "137.7151.07"),
         .package(url: "https://github.com/swhitty/FlyingFox.git", .upToNextMajor(from: "0.25.0")),
         .package(url: "https://github.com/swhitty/FlyingFoxMacros.git", .upToNextMajor(from: "0.2.0")),
 
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
         .package(url: "https://github.com/alloverse/OpenCombine.git", branch: "fix/vision-support"), // So we can use Combine on Linux.
         .package(url: "https://github.com/keyvariable/kvSIMD.swift.git", from: "1.1.0"), // So we can use simd on Linux
@@ -57,8 +56,7 @@ let package = Package(
         .target(
             name: "allonet2",
             dependencies: [
-                "BinaryCodable",
-                "AnyCodable",
+                "PotentCodables",
                 "FlyingFox",
                 "FlyingFoxMacros",
                 "Version",

--- a/Sources/allonet2/AlloSession.swift
+++ b/Sources/allonet2/AlloSession.swift
@@ -6,7 +6,8 @@
 //
 
 import Foundation
-import BinaryCodable
+import PotentCodables
+import PotentCBOR
 import OpenCombineShim
 import Logging
 
@@ -91,7 +92,7 @@ public class AlloSession : NSObject, TransportDelegate
     // TODO: this unsafe is going to bite me... store it threadsafely so logging can use it?
     nonisolated(unsafe) public var clientId: ClientId? { transport.clientId }
     
-    let encoder = BinaryEncoder()
+    let encoder = CBOREncoder()
     
     public func send(interaction: Interaction)
     {
@@ -200,7 +201,7 @@ public class AlloSession : NSObject, TransportDelegate
         }
     }
     
-    let decoder = BinaryDecoder()
+    let decoder = CBORDecoder()
     nonisolated public func transport(_ transport: Transport, didReceiveData data: Data, on channel: DataChannel)
     {
         switch channel.alloLabel {

--- a/Sources/allonet2/Interaction.swift
+++ b/Sources/allonet2/Interaction.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import AnyCodable
+import PotentCodables
 
 @MainActor
 public struct Interaction : Codable
@@ -66,7 +66,7 @@ public enum InteractionBody : Codable
     case tap(at: SIMD3<Float>) // oneway
     
     // - Other
-    case custom(value: [String: AnyCodable])
+    case custom(value: [String: AnyValue])
     
     // - Generic responses
     case error(domain: String, code: Int, description: String)

--- a/Sources/allonet2/Place.swift
+++ b/Sources/allonet2/Place.swift
@@ -136,7 +136,7 @@ public struct ComponentSet: CustomStringConvertible
 {
     public subscript<T>(componentType: T.Type) -> T? where T : Component
     {
-        return state.current.components[componentType.componentTypeId]?[id] as! T?
+        return state.current.components[componentType.componentTypeId]?[id]?.decoded() as! T?
     }
     public func set<T>(_ newValue: T) async throws(AlloverseError) where T: Component
     {
@@ -145,7 +145,7 @@ public struct ComponentSet: CustomStringConvertible
     }
     public subscript(componentTypeID: ComponentTypeID) -> (any Component)?
     {
-        return state.current.components[componentTypeID]?[id]
+        return state.current.components[componentTypeID]?[id]?.decoded()
     }
     
     private let state: PlaceState

--- a/Sources/allonet2/PlaceContents+Changes.swift
+++ b/Sources/allonet2/PlaceContents+Changes.swift
@@ -78,7 +78,7 @@ extension PlaceContents
                 {
                     added.append(.componentAdded(entityId, component))
                 }
-                else if !component.isEqualTo(prev!)
+                else if component != prev!
                 {
                     updated.append(.componentUpdated(entityId, component))
                 }
@@ -135,15 +135,15 @@ extension PlaceContents
             case .entityRemoved(let e):
                 entities[e.id] = nil
             case .componentAdded(let eid, let component):
-                let key = type(of:component).componentTypeId
+                let key = component.componentTypeId
                 lists[key, default: [:]][eid] = component
             case .componentUpdated(let eid, let component):
-                let key = type(of:component).componentTypeId
+                let key = component.componentTypeId
                 guard let _ = lists[key]?[eid] else { return nil }
                 lists[key]![eid]! = component
             case .componentRemoved(let edata, let component):
-                guard let _ = lists[type(of:component).componentTypeId] else { return nil }
-                lists[type(of:component).componentTypeId]![edata.id] = nil
+                guard let _ = lists[component.componentTypeId] else { return nil }
+                lists[component.componentTypeId]![edata.id] = nil
             }
         }
         return PlaceContents(revision: changeSet.toRevision, entities: entities, components: ComponentLists(lists: lists), logger: self.logger)

--- a/Sources/allonet2/PlaceServer/PlaceServer+ECS.swift
+++ b/Sources/allonet2/PlaceServer/PlaceServer+ECS.swift
@@ -88,11 +88,11 @@ extension PlaceServer
         {
             if let _ = place.current.components[$0.componentTypeId]?[eid]
             {
-                return PlaceChange.componentUpdated(eid, $0.base)
+                return PlaceChange.componentUpdated(eid, $0)
             }
             else
             {
-                return PlaceChange.componentAdded(eid, $0.base)
+                return PlaceChange.componentAdded(eid, $0)
             }
         }
         let removals = try remove.map
@@ -117,12 +117,12 @@ internal extension EntityDescription
             ent,
             [
                 .entityAdded(ent),
-                .componentAdded(ent.id, Transform()) // every entity should have Transform
+                .componentAdded(ent.id, AnyComponent(Transform())) // every entity should have Transform
             ]
-            + components.map { .componentAdded(ent.id, $0.base) }
+            + components.map { .componentAdded(ent.id, $0) }
             + children.flatMap {
                 let (child, changes) = $0.changes(for: ownerClientId)
-                let relationship = PlaceChange.componentAdded(child.id, Relationships(parent: ent.id))
+                let relationship = PlaceChange.componentAdded(child.id, AnyComponent(Relationships(parent: ent.id)))
                 return changes + [relationship]
             }
         )

--- a/Sources/allonet2/PlaceServer/PlaceServer+PlaceInteractions.swift
+++ b/Sources/allonet2/PlaceServer/PlaceServer+PlaceInteractions.swift
@@ -91,7 +91,7 @@ extension PlaceServer
             // Slightly offset each new incoming user so that users never exactly overlap. This fixes the audio bug. Not okay. https://www.notion.so/alloverse/Still-no-audio-when-testing-w-Tobes-2a4383c5f0558020a885fb75df1787b2
             newUserTform.matrix.translation.x += Float.random(in: -0.02...0.02)
             newUserTform.matrix.translation.z += Float.random(in: -0.02...0.02)
-            await appendChanges([.componentUpdated(avatar.id, newUserTform)])
+            await appendChanges([.componentUpdated(avatar.id, AnyComponent(newUserTform))])
         }
         
         // Finished announcing!

--- a/Sources/allonet2/SIMDExtensions.swift
+++ b/Sources/allonet2/SIMDExtensions.swift
@@ -15,38 +15,6 @@ public extension simd_float3x3 {
     }
 }
 
-extension simd_float4x4 : Codable
-{
-    public func encode(to encoder: Encoder) throws
-    {
-        var container = encoder.unkeyedContainer()
-        // Encode in row-major order: for each row, encode all columns.
-        for row in 0..<4
-        {
-            for col in 0..<4
-            {
-                try container.encode(self[col][row])
-            }
-        }
-    }
-    
-    public init(from decoder: Decoder) throws
-    {
-        var container = try decoder.unkeyedContainer()
-        var matrix = simd_float4x4()
-        // Decode in row-major order.
-        for row in 0..<4
-        {
-            for col in 0..<4
-            {
-                let value = try container.decode(Float.self)
-                matrix[col][row] = value
-            }
-        }
-        self = matrix
-    }
-}
-
 extension simd_float4x4 {
     public static var identity: simd_float4x4 {
         return matrix_identity_float4x4

--- a/Sources/allonet2/StandardComponents.swift
+++ b/Sources/allonet2/StandardComponents.swift
@@ -6,6 +6,7 @@
 //
 
 import simd
+import PotentCodables
 
 // MARK: Rendering/RealityKit related components
 // These all have an almost 1-to-1 mapping to a corresponding RealityKit component.
@@ -183,6 +184,15 @@ public struct LiveMediaListener: Component
     {
         self.mediaIds = mediaIds
     }
+}
+
+// MARK: - Custom components
+// You can implement your own Component subtypes and use them, as long as the compile time types are available to both producers and consumers of the type. If you provide a type that isn't available on the other side, it will be decoded as a CustomComponent that you can still use, but without type safety.
+
+public struct CustomComponent
+{
+    public var typeId: ComponentTypeID
+    public var fields: AnyValue
 }
 
 // MARK: - Implementation details

--- a/Sources/allonet2/StandardComponents.swift
+++ b/Sources/allonet2/StandardComponents.swift
@@ -6,6 +6,7 @@
 //
 
 import simd
+import SIMDTools // for float4x4 codable
 import PotentCodables
 
 // MARK: Rendering/RealityKit related components


### PR DESCRIPTION
Change AlloPlace to never actually decode Components to concrete types, and have it store the intermediate representation. Then, the client can choose to decode-- or not-- Components to concrete types.

This should be a nice backwards compatibility too. As long as we only add fields, AlloPlace won't care that the serialization has changed.

This also replaces the wire protocol from BinaryCodable to CBOR. In the future, we might continue onto ASN.1 which PotentCodable supports.

There are probably still some code paths where AnyCodable leaks through in an unexpected way, but everything seems to work that I've found so far, so we can fix those issues along the way.

CustomComponent isn't entirely thought out though. ComponentLists probably needs to be modified to support it in a sane manner.